### PR TITLE
feat: added gitattributes to make sure all file line endings are lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.pb.go     linguist-generated=true
+*           text=auto eol=lf


### PR DESCRIPTION
Added command in `.gitattributes` to make sure line endings are always LF. There shouldn't be any problem with Windows CRLF anymore.

@anz-bank/sysl-developers
